### PR TITLE
docs: add proprietary license and copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,28 @@
-The MIT License (MIT)
+Copyright (c) 2024-2025 Tanagra Space. All Rights Reserved.
 
-Copyright (c) 2013-2020 Michael Rose and contributors
+PROPRIETARY LICENSE
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This website and its contents, including but not limited to text, images, graphics,
+logos, code, and design elements, are the exclusive property of Tanagra Space.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+RESTRICTIONS:
+- No part of this website may be reproduced, distributed, or transmitted in any
+  form or by any means without the prior written permission of Tanagra Space.
+- Unauthorized copying, modification, distribution, or use of any content from
+  this website is strictly prohibited.
+- You may not use, copy, modify, merge, publish, distribute, sublicense, or sell
+  copies of this software or any portion thereof.
+
+For licensing inquiries, please contact Tanagra Space.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+TANAGRA SPACE BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+Note: The underlying Minimal Mistakes Jekyll theme is licensed under the MIT License
+by Michael Rose (https://github.com/mmistakes/minimal-mistakes). This proprietary
+license applies only to Tanagra Space's custom content, branding, and modifications.

--- a/_config.yml
+++ b/_config.yml
@@ -79,7 +79,7 @@ naver_site_verification  :
 yandex_site_verification :
 baidu_site_verification  :
 # Footer Related
-hide_footer              : true
+hide_footer              : false
 
 # Social Sharing
 twitter:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,6 +18,4 @@
   </ul>
 </div>
 
-{% comment %}
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>
-{% endcomment %}
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. All Rights Reserved.</div>


### PR DESCRIPTION
## Summary
- Replace MIT license with All Rights Reserved proprietary license for Tanagra Space
- Enable website footer with copyright notice displaying current year
- Acknowledge underlying Minimal Mistakes theme MIT license

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)