### PR TITLE
chore: add Google Analytics and update footer color

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,10 +98,10 @@ social:
 
 # Analytics
 analytics:
-  provider               : false # false (default), "google", "google-universal", "google-gtag", "custom"
+  provider               : "google-gtag" # false (default), "google", "google-universal", "google-gtag", "custom"
   google:
-    tracking_id          :
-    anonymize_ip         : # true, false (default)
+    tracking_id          : "G-D3Z8PVELJD"
+    anonymize_ip         : true # true, false (default)
 
 
 # Site Author

--- a/_sass/minimal-mistakes/skins/_sunrise.scss
+++ b/_sass/minimal-mistakes/skins/_sunrise.scss
@@ -12,7 +12,7 @@ $border-color: mix(#000, $background-color, 20%) !default;
 $code-background-color: mix(#fff, $background-color, 20%) !default;
 $code-background-color-dark: mix(#000, $background-color, 10%) !default;
 $form-background-color: mix(#fff, $background-color, 15%) !default;
-$footer-background-color: #f9b248 !default;
+$footer-background-color: #ebdbc2 !default;
 $link-color: mix(#000, $primary-color, 10%) !default;
 $link-color-hover: mix(#fff, $link-color, 25%) !default;
 $link-color-visited: mix(#000, $link-color, 25%) !default;


### PR DESCRIPTION
## Summary
- Configure Google Analytics (GA4) with gtag tracking ID `G-D3Z8PVELJD`
- Enable `anonymize_ip` for GDPR compliance
- Update footer background color from `#f9b248` to `#ebdbc2`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)