### PR TITLE
Fix the Oslo campaign report URL to doom.lb6aj.net

### DIFF
--- a/_pages/opssat-pretty-doomed.html
+++ b/_pages/opssat-pretty-doomed.html
@@ -84,7 +84,7 @@ stylesheet: "/assets/opssat-pretty-doomed/style.css"
     <h2>Who made it happen</h2>
     <p>The experiment depends on the amateur radio community, who form its ground segment. The transmissions were made by two volunteer radio amateur teams:</p>
     <ul>
-      <li><strong>Oslo Group of the Norwegian Radio Relay League (NRRL)</strong>, call sign LA4O, who ran the successful <a href="https://radio.lb6aj.net/doom/">July 2026 campaign</a> from a rooftop in Oslo.</li>
+      <li><strong>Oslo Group of the Norwegian Radio Relay League (NRRL)</strong>, call sign LA4O, who ran the successful <a href="https://doom.lb6aj.net">July 2026 campaign</a> from a rooftop in Oslo.</li>
       <li><strong>Radio amateurs in Legnica, Poland</strong> (SQ6RDP and SQ6QV), who ran the earlier link tests from April to June 2026.</li>
     </ul>
     <p>Full radio amateur credits are in the <a href="https://github.com/georgeslabreche/opssat-pretty-doomed#acknowledgements">project acknowledgements</a>.</p>
@@ -97,7 +97,7 @@ stylesheet: "/assets/opssat-pretty-doomed/style.css"
     <ul class="links">
       <li>📦 <a href="https://github.com/georgeslabreche/opssat-pretty-doomed">Source code and full flight record on GitHub</a></li>
       <li>🛰️ <a href="https://github.com/georgeslabreche/opssat-pretty-doomed/tree/main/pretty-doomed/docs/flight">Flight runs and per-pass analysis</a></li>
-      <li>📻 <a href="https://radio.lb6aj.net/doom/">The Oslo (LA4O) ground-station campaign report</a></li>
+      <li>📻 <a href="https://doom.lb6aj.net">The Oslo (LA4O) ground-station campaign report</a></li>
       <li>📡 <a href="https://opssat.esa.int/missions/pretty">About the PRETTY mission</a></li>
       <li>🎮 <a href="https://opssat.esa.int/">About OPS-SAT</a></li>
     </ul>


### PR DESCRIPTION
The Oslo (LA4O) ground-station campaign report lives at https://doom.lb6aj.net, not https://radio.lb6aj.net/doom/. Update both links on the PRETTY DOOMed landing page (the campaign mention and the Learn more list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)