### PR TITLE
Make the IDDQD easter egg mobile friendly with a five-tap god-mode toggle

### DIFF
--- a/_pages/opssat-pretty-doomed.html
+++ b/_pages/opssat-pretty-doomed.html
@@ -685,11 +685,7 @@ stylesheet: "/assets/opssat-pretty-doomed/style.css"
       });
     }
 
-    window.addEventListener('keydown', function (e) {
-      if (e.metaKey || e.ctrlKey || e.altKey || !e.key || e.key.length !== 1) return;
-      cheat = (cheat + e.key.toLowerCase()).slice(-5);
-      if (cheat !== 'iddqd') return;
-      cheat = '';
+    function toggleGod() {
       god = !god;
       stMessage(god ? 'Degreelessness Mode On' : 'Degreelessness Mode Off');
       stbar.classList.toggle('on', god);
@@ -704,6 +700,33 @@ stylesheet: "/assets/opssat-pretty-doomed/style.css"
         stopGallery();
         music.pause();
       }
+    }
+
+    window.addEventListener('keydown', function (e) {
+      if (e.metaKey || e.ctrlKey || e.altKey || !e.key || e.key.length !== 1) return;
+      cheat = (cheat + e.key.toLowerCase()).slice(-5);
+      if (cheat !== 'iddqd') return;
+      cheat = '';
+      toggleGod();
+    });
+
+    // On a touch screen there is no keyboard to type IDDQD on, so five quick
+    // taps anywhere toggle god mode instead. Taps on the page's own
+    // interactive pieces don't count: links and the players do their own
+    // thing, and the cacodemon and the signal have their own tap easter
+    // eggs. This listener is registered after the rocket listener above, so
+    // the tap that turns god mode on sees god=false there and doesn't also
+    // fire a rocket; once god mode is on, every tap fires at where it lands.
+    var taps = 0, lastTap = 0;
+    window.addEventListener('pointerdown', function (e) {
+      if (e.pointerType !== 'touch') return;
+      if (e.target.closest && e.target.closest('a, audio, video, .player, .sprite, .voice')) return;
+      var now = Date.now();
+      taps = (now - lastTap < 400) ? taps + 1 : 1;
+      lastTap = now;
+      if (taps < 5) return;
+      taps = 0;
+      toggleGod();
     });
 
     // Cacodemon easter egg. Click to punch it (the fist swings at the cursor).

--- a/assets/opssat-pretty-doomed/style.css
+++ b/assets/opssat-pretty-doomed/style.css
@@ -13,6 +13,7 @@ body {
   line-height: 1.6;
   color: var(--ink);
   background: var(--bg);
+  touch-action: manipulation;   /* rapid taps (IDDQD, rockets) must not double-tap-zoom */
 }
 a { color: var(--accent-dark); }
 code { background: rgba(0,0,0,0.06); padding: 0.12em 0.4em; border-radius: 4px;
@@ -139,6 +140,8 @@ body.god-flash::after { content: ""; position: fixed; inset: 0; z-index: 9997;
 .boom { position: fixed; z-index: 9996; pointer-events: none; transform: translate(-50%, -55%);
   height: auto; image-rendering: pixelated; }
 body.god .fist-follow { display: none !important; }
+/* Tapping to fire on a touch screen must not select the text it blasts. */
+body.god { -webkit-user-select: none; user-select: none; }
 .ltr.flying { display: inline-block; will-change: transform; }   /* transforms need a box */
 .monster { position: fixed; z-index: 9990; pointer-events: none;
   transform-origin: bottom center; transition: opacity 0.4s ease; }


### PR DESCRIPTION
### :rocket: Overview

The IDDQD god-mode easter egg on the PRETTY DOOMed page required typing the cheat on a keyboard, which left touch devices out. Five quick taps anywhere on the screen now toggle god mode on mobile, and rockets fire at wherever you tap.

### :construction_site: Changes

1. Five consecutive touch taps, each within 400ms of the previous, toggle god mode (and five more toggle it off). The keyboard cheat is unchanged on desktop; the toggle logic is shared via a new `toggleGod()`.
2. Taps on the page's own interactive pieces don't count toward the five: links, the audio/video players, the cacodemon (which has its own five-tap kill), and the voice signal.
3. The tap counter is registered after the rocket listener, so the activating tap doesn't also fire a stray rocket; once god mode is on, every tap fires at the tap point (which the rocket listener already supported via `pointerdown` coordinates).
4. `touch-action: manipulation` on `body`, so rapid tapping doesn't trigger iOS double-tap zoom.
5. `user-select: none` while god mode is on, so tapping paragraphs to blast the letters apart doesn't select the text.

### :comet: Commits

- b783fdaf Make the IDDQD easter egg mobile friendly: five taps toggle god mode

### :anchor: Tests

- Inline script extracted and passed `node --check`.
- Verified locally with `bundle exec jekyll serve`: page builds and serves. To try it, open the page in a browser's touch/device emulation (or on a phone) and tap five times quickly — the screen flashes gold, the status bar comes out, and taps fire rockets where they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
